### PR TITLE
Add local storage module

### DIFF
--- a/src/persistence/LocalStorage.js
+++ b/src/persistence/LocalStorage.js
@@ -1,0 +1,25 @@
+const withLocalStorage = (fn) => {
+  const storage = window.localStorage
+  if (!storage) return undefined
+
+  try {
+    return fn(storage)
+  } catch (err) {
+    return undefined
+  }
+}
+
+export default class LocalStorage {
+  static set(key, value) {
+    withLocalStorage((storage) => {
+      const json = JSON.stringify(value)
+      storage.setItem(key, json)
+    })
+  }
+
+  static get(key) {
+    return withLocalStorage((storage) => {
+      return JSON.parse(storage.getItem(key))
+    })
+  }
+}

--- a/tests/persistence/LocalStorage.test.js
+++ b/tests/persistence/LocalStorage.test.js
@@ -1,0 +1,33 @@
+import localStorage from '../../src/persistence/LocalStorage'
+
+const testData = { "test-data": 42 }
+
+describe("When local storage api is available", () => {
+  const mockLocalStorage = {
+    getItem: jest.fn(() => '{"test-data":42}'),
+    setItem: jest.fn()
+  }
+
+  beforeAll(() => { window.localStorage = mockLocalStorage })
+  afterAll(() => { window.localStorage = undefined })
+
+  it("should save an object to local storate", () => {
+    localStorage.set("test", testData)
+    expect(mockLocalStorage.setItem).toBeCalledWith("test", '{"test-data":42}')
+  })
+
+  it("should load an object from local storage", () => {
+    expect(localStorage.get("test")).toEqual(testData)
+    expect(mockLocalStorage.getItem).toBeCalledWith("test")
+  })
+})
+
+describe("When local storage api os NOT available", () => {
+  it("should not fail when trying to save an object", () => {
+    localStorage.set("test", testData)
+  })
+
+  it("should return undefined when trying to load an object", () => {
+    expect(localStorage.get("test")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Simple wrapper for local storage API. I'm planing to use this to persist parts of the global state, like the last endpoint and secret used so that we can allow people to refresh the application without asking for these information again.