### PR TITLE
Use onBeforeChange for database form

### DIFF
--- a/src/database-form/DatabaseForm.js
+++ b/src/database-form/DatabaseForm.js
@@ -34,7 +34,7 @@ export class DatabaseForm extends Component {
           required={true}
           description="This name is used in queries and API calls."
           value={form.name}
-          onChanged={this.onChange.bind(this, "name")}/>
+          onBeforeChange={this.onChange.bind(this, "name")}/>
       </SchemaForm>
     )
   }


### PR DESCRIPTION
`onChanged` has a terrible delay. I usually create databases with half of the name I intended to.