### PR TITLE
database forms redirect on success

### DIFF
--- a/src/database-form/DatabaseForm.js
+++ b/src/database-form/DatabaseForm.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-// import { Link } from 'react-router';
+import { browserHistory } from 'react-router';
 import {TextField} from 'office-ui-fabric-react'
 import SchemaForm from "../schema-form/SchemaForm"
 import faunadb from 'faunadb';
@@ -13,10 +13,12 @@ export class DatabaseForm extends Component {
     this.onChange = this.onChange.bind(this);
   }
   onSubmit() {
+    var context = this.props.splat ? this.props.splat+"/"+this.state.form.name : this.state.form.name;
     return this.props.scopedAdminClient
       .query(q.Create(Ref("databases"), { name: this.state.form.name }))
       .then((res)=>{
         this.setState({form:{name:""}});
+        browserHistory.push("/db/"+context+"/databases");
       })
   }
   onChange(field, value) {

--- a/src/databases/Databases.js
+++ b/src/databases/Databases.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { browserHistory } from 'react-router';
 import {TextField} from 'office-ui-fabric-react'
 import SchemaForm from "../schema-form/SchemaForm"
 import {DatabaseForm} from '../database-form/DatabaseForm';
@@ -39,6 +40,7 @@ export class DeleteDatabaseForm extends Component {
       .query(q.Delete(q.Ref("databases/"+this.state.name)))
       .then((res)=>{
         this.setState({name:"", correct : false});
+        browserHistory.push("/db/"+parentSplat+"/databases");
       })
   }
   nameChange(value) {


### PR DESCRIPTION
The create database form changes the URL to the new database path.
The delete database form changes the URL to the parent database path.

This exposes some behavior being tracked as #96. Where the class and index names in the nav tree don't redraw. But that but is secondary to this feature, so I think we can merge this now while we fix that.