### PR TITLE
skip the notification dispatch if there are no notifications

### DIFF
--- a/src/persistence/FaunaDB.js
+++ b/src/persistence/FaunaDB.js
@@ -11,8 +11,10 @@ import {
 var errors = []
 
 const onSuccess = dispatch => () => {
-  dispatch(removeNotification(errors))
-  errors = []
+  if (errors.length > 0) {
+    dispatch(removeNotification(errors))
+    errors = []
+  }
 }
 
 const onError = dispatch => newErrors => {


### PR DESCRIPTION
when the notification dispatch is empty, it is still clogging the logs with output. this fixes that.