### PR TITLE
Fix repl result when the answer is a instance of a class

### DIFF
--- a/src/index-query/IndexQuery.js
+++ b/src/index-query/IndexQuery.js
@@ -148,6 +148,8 @@ export class QueryResult extends Component {
   }
   makeResultIntoTableData(result) {
     if (!(result && result.data)) return null;
+    if (!Array.isArray(result.data)) return null
+
     var firstResult = result.data[0];
     if (!firstResult) return [{message:"Empty result set, no matching data."}];
     var keynames, multiColumn;


### PR DESCRIPTION
Without this fix, the query `q.Get(q.Ref("some/ref/233"))` renders as `Empty result set, no matching data.`.